### PR TITLE
Refactor booking model and validation to remove PAYPAL payment method

### DIFF
--- a/src/models/booking.model.ts
+++ b/src/models/booking.model.ts
@@ -27,7 +27,7 @@ class Booking extends Model<
 		| "REJECTED"
 		| "EXPIRED";
 	declare paymentStatus: "PENDING" | "PAID" | "REFUNDED" | "FAILED";
-	declare paymentMethod: CreationOptional<"PAYPAL" | "CASH">;
+	declare paymentMethod: CreationOptional<"CASH">;
 	declare totalPrice: number;
 	declare createdAt: CreationOptional<Date>;
 	declare updatedAt: CreationOptional<Date>;
@@ -85,7 +85,7 @@ Booking.init(
 			defaultValue: "PENDING",
 		},
 		paymentMethod: {
-			type: DataTypes.ENUM("PAYPAL", "CASH"),
+			type: DataTypes.ENUM("CASH"),
 			allowNull: true,
 		},
 		totalPrice: {

--- a/src/routes/v1/validators/booking.validator.ts
+++ b/src/routes/v1/validators/booking.validator.ts
@@ -24,8 +24,8 @@ const BookingValidator: BookingValidator = {
 			.withMessage("End date is required"),
 		body("paymentMethod")
 			.optional()
-			.isIn(["PAYPAL", "CASH"])
-			.withMessage("Payment method must be PAYPAL or CASH"),
+			.isIn(["CASH"])
+			.withMessage("Payment method must be CASH"),
 	],
 
 	updateBookingStatus: [

--- a/src/services/booking.service.ts
+++ b/src/services/booking.service.ts
@@ -41,7 +41,7 @@ type CreateBookingData = {
 	clientId: number;
 	startDate: Date;
 	endDate: Date;
-	paymentMethod?: "PAYPAL" | "CASH";
+	paymentMethod?: "CASH";
 };
 
 interface UpdateBookingStatusData {
@@ -59,7 +59,7 @@ interface UpdateBookingStatusData {
 interface UpdatePaymentStatusData {
 	bookingId: number;
 	paymentStatus: "PENDING" | "PAID" | "REFUNDED" | "FAILED";
-	paymentMethod?: "PAYPAL" | "CASH";
+	paymentMethod?: "CASH";
 }
 
 const BookingService = {


### PR DESCRIPTION
- Updated Booking model to only support "CASH" as a payment method.
- Adjusted BookingValidator to enforce "CASH" as the only valid payment method.
- Modified CreateBookingData and UpdatePaymentStatusData interfaces to reflect the change in payment method options.